### PR TITLE
Update to latest OpenBSD sed(1), with some small tweaks for LiteBSD.

### DIFF
--- a/usr.bin/sed/Makefile
+++ b/usr.bin/sed/Makefile
@@ -1,6 +1,9 @@
-#	@(#)Makefile	8.1 (Berkeley) 6/6/93
+#	$OpenBSD: Makefile,v 1.4 2010/01/04 17:50:39 deraadt Exp $
 
 PROG=	sed
-SRCS=	compile.c main.c misc.c process.c
+SRCS=	compile.c main.c misc.c process.c dirname.c reallocarray.c
+
+CFLAGS+=-ffunction-sections -fdata-sections
+LDFLAGS+=-Wl,--gc-sections
 
 .include <bsd.prog.mk>

--- a/usr.bin/sed/POSIX
+++ b/usr.bin/sed/POSIX
@@ -1,4 +1,5 @@
-#	@(#)POSIX	8.1 (Berkeley) 6/6/93
+#	$OpenBSD: POSIX,v 1.2 1996/06/26 05:39:04 deraadt Exp $
+#	from: @(#)POSIX	8.1 (Berkeley) 6/6/93
 
 Comments on the IEEE P1003.2 Draft 12
      Part 2: Shell and Utilities

--- a/usr.bin/sed/TEST/hanoi.sed
+++ b/usr.bin/sed/TEST/hanoi.sed
@@ -1,6 +1,7 @@
+#	$OpenBSD: hanoi.sed,v 1.2 1996/06/26 05:39:09 deraadt Exp $
 # Towers of Hanoi in sed.
 #
-#	@(#)hanoi.sed	8.1 (Berkeley) 6/6/93
+#	from: @(#)hanoi.sed	8.1 (Berkeley) 6/6/93
 #
 #
 # Ex:

--- a/usr.bin/sed/TEST/math.sed
+++ b/usr.bin/sed/TEST/math.sed
@@ -1,5 +1,6 @@
+#	$OpenBSD: math.sed,v 1.2 1996/06/26 05:39:10 deraadt Exp $
 #
-#	@(#)math.sed	8.1 (Berkeley) 6/6/93
+#	from: @(#)math.sed	8.1 (Berkeley) 6/6/93
 #
 # Addition and multiplication in sed.
 # ++ for a limited time only do (expr) too!!!

--- a/usr.bin/sed/TEST/sed.test
+++ b/usr.bin/sed/TEST/sed.test
@@ -1,4 +1,5 @@
 #!/bin/sh -
+#	$OpenBSD: sed.test,v 1.4 2008/10/07 15:02:45 millert Exp $
 #
 # Copyright (c) 1992 Diomidis Spinellis.
 # Copyright (c) 1992, 1993
@@ -12,11 +13,7 @@
 # 2. Redistributions in binary form must reproduce the above copyright
 #    notice, this list of conditions and the following disclaimer in the
 #    documentation and/or other materials provided with the distribution.
-# 3. All advertising materials mentioning features or use of this software
-#    must display the following acknowledgement:
-#	This product includes software developed by the University of
-#	California, Berkeley and its contributors.
-# 4. Neither the name of the University nor the names of its contributors
+# 3. Neither the name of the University nor the names of its contributors
 #    may be used to endorse or promote products derived from this software
 #    without specific prior written permission.
 #
@@ -32,7 +29,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
-#	@(#)sed.test	8.1 (Berkeley) 6/6/93
+#	from: @(#)sed.test	8.1 (Berkeley) 6/6/93
 #
 
 # sed Regression Tests
@@ -43,7 +40,7 @@
 
 main()
 {
-	BASE=/usr/old/bin/sed
+	BASE=/usr/bin/sed
 	BASELOG=sed.out
 	TEST=../obj/sed
 	TESTLOG=nsed.out
@@ -57,7 +54,7 @@ main()
 	exec 4>&1 5>&2
 
 	# Set these flags to get messages about known problems
-	BSD=1
+	BSD=0
 	GNU=0
 	SUN=0
 	tests $BASE $BASELOG

--- a/usr.bin/sed/defs.h
+++ b/usr.bin/sed/defs.h
@@ -1,3 +1,4 @@
+/*	$OpenBSD: defs.h,v 1.7 2015/10/26 22:24:44 jca Exp $ */
 /*-
  * Copyright (c) 1992 Diomidis Spinellis.
  * Copyright (c) 1992, 1993
@@ -14,11 +15,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -34,7 +31,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- *	@(#)defs.h	8.1 (Berkeley) 6/6/93
+ *	from: @(#)defs.h	8.1 (Berkeley) 6/6/93
  */
 
 /*
@@ -100,6 +97,7 @@ enum e_args {
 	TEXT,			/* a c i */
 	NONSEL,			/* ! */
 	GROUP,			/* { */
+	ENDGROUP,		/* } */
 	COMMENT,		/* # */
 	BRANCH,			/* b t */
 	LABEL,			/* : */
@@ -130,6 +128,7 @@ typedef struct {
 	char *space;		/* Current space pointer. */
 	size_t len;		/* Current length. */
 	int deleted;		/* If deleted. */
+	int append_newline;	/* If originally terminated by \n. */
 	char *back;		/* Backing memory. */
 	size_t blen;		/* Backing memory length. */
 } SPACE;
@@ -137,8 +136,12 @@ typedef struct {
 /*
  * Error severity codes:
  */
-#define	FATAL		0	/* Exit immediately with 1 */
-#define	ERROR		1	/* Continue, but change exit value */
-#define	WARNING		2	/* Just print the warning */
-#define	COMPILE		3	/* Print error, count and finish script */
-#define	COMPILE2	3	/* Print error, count and finish script */
+#define	WARNING		0	/* Just print the warning */
+#define	FATAL		1	/* Exit immediately with 1 */
+#define	COMPILE		2	/* Print error, count and finish script */
+
+/*
+ * Round up to the nearest multiple of _POSIX2_LINE_MAX
+ */
+#define ROUNDLEN(x) \
+    (((x) + _POSIX2_LINE_MAX - 1) & ~(_POSIX2_LINE_MAX - 1))

--- a/usr.bin/sed/dirname.c
+++ b/usr.bin/sed/dirname.c
@@ -1,0 +1,68 @@
+/*	$OpenBSD: dirname.c,v 1.15 2013/09/30 12:02:33 millert Exp $	*/
+
+/*
+ * Copyright (c) 1997, 2004 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+
+/* A slightly modified copy of this file exists in libexec/ld.so */
+
+char *
+dirname(const char *path)
+{
+	static char dname[PATH_MAX];
+	size_t len;
+	const char *endp;
+
+	/* Empty or NULL string gets treated as "." */
+	if (path == NULL || *path == '\0') {
+		dname[0] = '.';
+		dname[1] = '\0';
+		return (dname);
+	}
+
+	/* Strip any trailing slashes */
+	endp = path + strlen(path) - 1;
+	while (endp > path && *endp == '/')
+		endp--;
+
+	/* Find the start of the dir */
+	while (endp > path && *endp != '/')
+		endp--;
+
+	/* Either the dir is "/" or there are no slashes */
+	if (endp == path) {
+		dname[0] = *endp == '/' ? '/' : '.';
+		dname[1] = '\0';
+		return (dname);
+	} else {
+		/* Move forward past the separating slashes */
+		do {
+			endp--;
+		} while (endp > path && *endp == '/');
+	}
+
+	len = endp - path + 1;
+	if (len >= sizeof(dname)) {
+		errno = ENAMETOOLONG;
+		return (NULL);
+	}
+	memcpy(dname, path, len);
+	dname[len] = '\0';
+	return (dname);
+}

--- a/usr.bin/sed/extern.h
+++ b/usr.bin/sed/extern.h
@@ -1,3 +1,4 @@
+/*	$OpenBSD: extern.h,v 1.11 2015/10/26 14:08:47 mmcc Exp $ */
 /*-
  * Copyright (c) 1992 Diomidis Spinellis.
  * Copyright (c) 1992, 1993
@@ -14,11 +15,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -34,7 +31,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- *	@(#)extern.h	8.1 (Berkeley) 6/6/93
+ *	from: @(#)extern.h	8.1 (Berkeley) 6/6/93
  */
 
 extern struct s_command *prog;
@@ -42,18 +39,23 @@ extern struct s_appends *appends;
 extern regmatch_t *match;
 extern size_t maxnsub;
 extern u_long linenum;
-extern int appendnum;
-extern int lastline;
-extern int aflag, eflag, nflag;
-extern char *fname;
+extern size_t appendnum;
+extern int Eflag, aflag, eflag, nflag;
+extern const char *fname, *outfname;
+extern FILE *infile, *outfile;
 
-void	 cfclose __P((struct s_command *, struct s_command *));
-void	 compile __P((void));
-void	 cspace __P((SPACE *, char *, size_t, enum e_spflag));
-char	*cu_fgets __P((char *, int));
-void	 err __P((int, const char *, ...));
-int	 mf_fgets __P((SPACE *, enum e_spflag));
-void	 process __P((void));
-char	*strregerror __P((int, regex_t *));
-void	*xmalloc __P((u_int));
-void	*xrealloc __P((void *, u_int));
+void	 cfclose(struct s_command *, struct s_command *);
+void	 compile(void);
+void	 cspace(SPACE *, const char *, size_t, enum e_spflag);
+char	*cu_fgets(char **, size_t *);
+char	*dirname(const char *);
+void	 error(int, const char *, ...);
+int	 mf_fgets(SPACE *, enum e_spflag);
+int	 lastline(void);
+void	 process(void);
+void	*reallocarray(void *, size_t, size_t);
+void	 resetranges(void);
+char	*strregerror(int, regex_t *);
+void	*xmalloc(size_t);
+void	*xreallocarray(void *, size_t, size_t);
+void	*xrealloc(void *, size_t);

--- a/usr.bin/sed/misc.c
+++ b/usr.bin/sed/misc.c
@@ -1,3 +1,5 @@
+/*	$OpenBSD: misc.c,v 1.11 2015/10/26 14:08:47 mmcc Exp $	*/
+
 /*-
  * Copyright (c) 1992 Diomidis Spinellis.
  * Copyright (c) 1992, 1993
@@ -14,11 +16,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -35,10 +33,6 @@
  * SUCH DAMAGE.
  */
 
-#ifndef lint
-static char sccsid[] = "@(#)misc.c	8.1 (Berkeley) 6/6/93";
-#endif /* not lint */
-
 #include <sys/types.h>
 
 #include <errno.h>
@@ -46,6 +40,7 @@ static char sccsid[] = "@(#)misc.c	8.1 (Berkeley) 6/6/93";
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 
 #include "defs.h"
 #include "extern.h"
@@ -54,13 +49,22 @@ static char sccsid[] = "@(#)misc.c	8.1 (Berkeley) 6/6/93";
  * malloc with result test
  */
 void *
-xmalloc(size)
-	u_int size;
+xmalloc(size_t size)
 {
 	void *p;
 
 	if ((p = malloc(size)) == NULL)
-		err(FATAL, "%s", strerror(errno));
+		error(FATAL, "%s", strerror(errno));
+	return (p);
+}
+
+void *
+xreallocarray(void *o, size_t nmemb, size_t size)
+{
+	void *p;
+
+	if ((p = reallocarray(o, nmemb, size)) == NULL)
+		error(FATAL, "%s", strerror(errno));
 	return (p);
 }
 
@@ -68,15 +72,11 @@ xmalloc(size)
  * realloc with result test
  */
 void *
-xrealloc(p, size)
-	void *p;
-	u_int size;
+xrealloc(void *p, size_t size)
 {
-	if (p == NULL)			/* Compatibility hack. */
-		return (xmalloc(size));
 
 	if ((p = realloc(p, size)) == NULL)
-		err(FATAL, "%s", strerror(errno));
+		error(FATAL, "%s", strerror(errno));
 	return (p);
 }
 
@@ -86,45 +86,27 @@ xrealloc(p, size)
  * the buffer).
  */
 char *
-strregerror(errcode, preg)
-	int errcode;
-	regex_t *preg;
+strregerror(int errcode, regex_t *preg)
 {
 	static char *oe;
 	size_t s;
 
-	if (oe != NULL)
-		free(oe);
+	free(oe);
 	s = regerror(errcode, preg, "", 0);
 	oe = xmalloc(s);
 	(void)regerror(errcode, preg, oe, s);
 	return (oe);
 }
 
-#if __STDC__
-#include <stdarg.h>
-#else
-#include <varargs.h>
-#endif
 /*
  * Error reporting function
  */
 void
-#if __STDC__
-err(int severity, const char *fmt, ...)
-#else
-err(severity, fmt, va_alist)
-	int severity;
-	char *fmt;
-        va_dcl
-#endif
+error(int severity, const char *fmt, ...)
 {
 	va_list ap;
-#if __STDC__
+
 	va_start(ap, fmt);
-#else
-	va_start(ap);
-#endif
 	(void)fprintf(stderr, "sed: ");
 	switch (severity) {
 	case WARNING:

--- a/usr.bin/sed/process.c
+++ b/usr.bin/sed/process.c
@@ -1,6 +1,8 @@
+/*	$OpenBSD: process.c,v 1.27 2015/10/26 14:08:47 mmcc Exp $	*/
+
 /*-
  * Copyright (c) 1992 Diomidis Spinellis.
- * Copyright (c) 1992, 1993, 1994
+ * Copyright (c) 1992, 1993
  *	The Regents of the University of California.  All rights reserved.
  *
  * This code is derived from software contributed to Berkeley by
@@ -14,11 +16,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -35,13 +33,8 @@
  * SUCH DAMAGE.
  */
 
-#ifndef lint
-static char sccsid[] = "@(#)process.c	8.6 (Berkeley) 4/20/94";
-#endif /* not lint */
-
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/ioctl.h>
 #include <sys/uio.h>
 
 #include <ctype.h>
@@ -61,19 +54,20 @@ static SPACE HS, PS, SS;
 #define	pd		PS.deleted
 #define	ps		PS.space
 #define	psl		PS.len
+#define	psanl		PS.append_newline
 #define	hs		HS.space
 #define	hsl		HS.len
 
-static inline int	 applies __P((struct s_command *));
-static void		 flush_appends __P((void));
-static void		 lputs __P((char *));
-static inline int	 regexec_e __P((regex_t *, const char *, int, int, size_t));
-static void		 regsub __P((SPACE *, char *, char *));
-static int		 substitute __P((struct s_command *));
+static inline int	 applies(struct s_command *);
+static void		 flush_appends(void);
+static void		 lputs(char *);
+static inline int	 regexec_e(regex_t *, const char *, int, int, size_t);
+static void		 regsub(SPACE *, char *, char *);
+static int		 substitute(struct s_command *);
 
 struct s_appends *appends;	/* Array of pointers to strings to append. */
 static int appendx;		/* Index into appends array. */
-int appendnum;			/* Size of appends array. */
+size_t appendnum;		/* Size of appends array. */
 
 static int lastaddr;		/* Set by applies if last address of a range. */
 static int sdone;		/* If any substitutes since last line input. */
@@ -82,18 +76,23 @@ static regex_t *defpreg;
 size_t maxnsub;
 regmatch_t *match;
 
-#define OUT(s) { fwrite(s, sizeof(u_char), psl, stdout); }
+#define OUT() do {\
+	fwrite(ps, 1, psl, outfile);\
+	if (psanl) fputc('\n', outfile);\
+} while (0)
 
 void
-process()
+process(void)
 {
 	struct s_command *cp;
 	SPACE tspace;
-	size_t len;
-	char oldc, *p;
+	size_t len, oldpsl;
+	char *p;
+	int oldpsanl;
 
 	for (linenum = 0; mf_fgets(&PS, REPLACE);) {
 		pd = 0;
+top:
 		cp = prog;
 redirect:
 		while (cp != NULL) {
@@ -106,10 +105,12 @@ redirect:
 				cp = cp->u.c;
 				goto redirect;
 			case 'a':
-				if (appendx >= appendnum)
-					appends = xrealloc(appends,
-					    sizeof(struct s_appends) *
-					    (appendnum *= 2));
+				if (appendx >= appendnum) {
+					appends = xreallocarray(appends,
+					    appendnum,
+					    2 * sizeof(struct s_appends));
+					appendnum *= 2;
+				}
 				appends[appendx].type = AP_STRING;
 				appends[appendx].s = cp->t;
 				appends[appendx].len = strlen(cp->t);
@@ -121,8 +122,8 @@ redirect:
 			case 'c':
 				pd = 1;
 				psl = 0;
-				if (cp->a2 == NULL || lastaddr)
-					(void)printf("%s", cp->t);
+				if (cp->a2 == NULL || lastaddr || lastline())
+					(void)fprintf(outfile, "%s", cp->t);
 				break;
 			case 'd':
 				pd = 1;
@@ -130,34 +131,38 @@ redirect:
 			case 'D':
 				if (pd)
 					goto new;
-				if ((p = memchr(ps, '\n', psl)) == NULL)
+				if (psl == 0 ||
+				    (p = memchr(ps, '\n', psl)) == NULL) {
 					pd = 1;
-				else {
-					psl -= (p - ps) + 1;
+					goto new;
+				} else {
+					psl -= (p + 1) - ps;
 					memmove(ps, p + 1, psl);
+					goto top;
 				}
-				goto new;
 			case 'g':
 				cspace(&PS, hs, hsl, REPLACE);
 				break;
 			case 'G':
+				cspace(&PS, "\n", 1, 0);
 				cspace(&PS, hs, hsl, 0);
 				break;
 			case 'h':
 				cspace(&HS, ps, psl, REPLACE);
 				break;
 			case 'H':
+				cspace(&HS, "\n", 1, 0);
 				cspace(&HS, ps, psl, 0);
 				break;
 			case 'i':
-				(void)printf("%s", cp->t);
+				(void)fprintf(outfile, "%s", cp->t);
 				break;
 			case 'l':
 				lputs(ps);
 				break;
 			case 'n':
 				if (!nflag && !pd)
-					OUT(ps)
+					OUT();
 				flush_appends();
 				if (!mf_fgets(&PS, REPLACE))
 					exit(0);
@@ -165,38 +170,41 @@ redirect:
 				break;
 			case 'N':
 				flush_appends();
-				if (!mf_fgets(&PS, 0)) {
-					if (!nflag && !pd)
-						OUT(ps)
+				cspace(&PS, "\n", 1, 0);
+				if (!mf_fgets(&PS, 0))
 					exit(0);
-				}
 				break;
 			case 'p':
 				if (pd)
 					break;
-				OUT(ps)
+				OUT();
 				break;
 			case 'P':
 				if (pd)
 					break;
 				if ((p = memchr(ps, '\n', psl)) != NULL) {
-					oldc = *p;
-					*p = '\0';
+					oldpsl = psl;
+					oldpsanl = psanl;
+					psl = p - ps;
+					psanl = 1;
+					OUT();
+					psl = oldpsl;
+				} else {
+					OUT();
 				}
-				OUT(ps)
-				if (p != NULL)
-					*p = oldc;
 				break;
 			case 'q':
 				if (!nflag && !pd)
-					OUT(ps)
+					OUT();
 				flush_appends();
 				exit(0);
 			case 'r':
-				if (appendx >= appendnum)
-					appends = xrealloc(appends,
-					    sizeof(struct s_appends) *
-					    (appendnum *= 2));
+				if (appendx >= appendnum) {
+					appends = xreallocarray(appends,
+					    appendnum,
+					    2 * sizeof(struct s_appends));
+					appendnum *= 2;
+				}
 				appends[appendx].type = AP_FILE;
 				appends[appendx].s = cp->t;
 				appends[appendx].len = strlen(cp->t);
@@ -218,10 +226,11 @@ redirect:
 				if (cp->u.fd == -1 && (cp->u.fd = open(cp->t,
 				    O_WRONLY|O_APPEND|O_CREAT|O_TRUNC,
 				    DEFFILEMODE)) == -1)
-					err(FATAL, "%s: %s\n",
+					error(FATAL, "%s: %s",
 					    cp->t, strerror(errno));
-				if (write(cp->u.fd, ps, psl) != psl)
-					err(FATAL, "%s: %s\n",
+				if (write(cp->u.fd, ps, psl) != psl ||
+				    write(cp->u.fd, "\n", 1) != 1)
+					error(FATAL, "%s: %s",
 					    cp->t, strerror(errno));
 				break;
 			case 'x':
@@ -229,25 +238,26 @@ redirect:
 					cspace(&HS, "", 0, REPLACE);
 				tspace = PS;
 				PS = HS;
+				psanl = tspace.append_newline;
 				HS = tspace;
 				break;
 			case 'y':
-				if (pd)
+				if (pd || psl == 0)
 					break;
-				for (p = ps, len = psl; --len; ++p)
-					*p = cp->u.y[*p];
+				for (p = ps, len = psl; len--; ++p)
+					*p = cp->u.y[(unsigned char)*p];
 				break;
 			case ':':
 			case '}':
 				break;
 			case '=':
-				(void)printf("%lu\n", linenum);
+				(void)fprintf(outfile, "%lu\n", linenum);
 			}
 			cp = cp->next;
 		} /* for all cp */
 
 new:		if (!nflag && !pd)
-			OUT(ps)
+			OUT();
 		flush_appends();
 	} /* for all lines */
 }
@@ -258,15 +268,14 @@ new:		if (!nflag && !pd)
  */
 #define	MATCH(a)						\
 	(a)->type == AT_RE ? regexec_e((a)->u.r, ps, 0, 1, psl) :	\
-	    (a)->type == AT_LINE ? linenum == (a)->u.l : lastline
+	    (a)->type == AT_LINE ? linenum == (a)->u.l : lastline()
 
 /*
  * Return TRUE if the command applies to the current line.  Sets the inrange
  * flag to process ranges.  Interprets the non-select (``!'') flag.
  */
 static inline int
-applies(cp)
-	struct s_command *cp;
+applies(struct s_command *cp)
 {
 	int r;
 
@@ -297,7 +306,20 @@ applies(cp)
 			r = 0;
 	else
 		r = MATCH(cp->a1);
-	return (cp->nonsel ? ! r : r);
+	return (cp->nonsel ? !r : r);
+}
+
+/*
+ * Reset all inrange markers.
+ */
+void
+resetranges(void)
+{
+	struct s_command *cp;
+
+	for (cp = prog; cp; cp = cp->code == '{' ? cp->u.c : cp->next)
+		if (cp->a2)
+			cp->inrange = 0;
 }
 
 /*
@@ -307,13 +329,12 @@ applies(cp)
  *	and then swap them.
  */
 static int
-substitute(cp)
-	struct s_command *cp;
+substitute(struct s_command *cp)
 {
 	SPACE tspace;
 	regex_t *re;
-	size_t re_off, slen;
-	int lastempty, n;
+	regoff_t slen;
+	int n, lastempty;
 	char *s;
 
 	s = ps;
@@ -321,72 +342,67 @@ substitute(cp)
 	if (re == NULL) {
 		if (defpreg != NULL && cp->u.s->maxbref > defpreg->re_nsub) {
 			linenum = cp->u.s->linenum;
-			err(COMPILE, "\\%d not defined in the RE",
+			error(COMPILE, "\\%d not defined in the RE",
 			    cp->u.s->maxbref);
 		}
 	}
 	if (!regexec_e(re, s, 0, 0, psl))
 		return (0);
 
-  	SS.len = 0;				/* Clean substitute space. */
-  	slen = psl;
-  	n = cp->u.s->n;
+	SS.len = 0;				/* Clean substitute space. */
+	slen = psl;
+	n = cp->u.s->n;
 	lastempty = 1;
 
-  	switch (n) {
-  	case 0:					/* Global */
-  		do {
-			if (lastempty || match[0].rm_so != match[0].rm_eo) {
-				/* Locate start of replaced string. */
-				re_off = match[0].rm_so;
-				/* Copy leading retained string. */
-				cspace(&SS, s, re_off, APPEND);
-				/* Add in regular expression. */
-				regsub(&SS, s, cp->u.s->new);
-			}
+	do {
+		/* Copy the leading retained string. */
+		if (n <= 1 && match[0].rm_so)
+			cspace(&SS, s, match[0].rm_so, APPEND);
 
-  			/* Move past this match. */
-			if (match[0].rm_so != match[0].rm_eo) {
-				s += match[0].rm_eo;
-				slen -= match[0].rm_eo;
-				lastempty = 0;
+		/* Skip zero-length matches right after other matches. */
+		if (lastempty || match[0].rm_so ||
+		    match[0].rm_so != match[0].rm_eo) {
+			if (n <= 1) {
+				/* Want this match: append replacement. */
+				regsub(&SS, s, cp->u.s->new);
+				if (n == 1)
+					n = -1;
 			} else {
-				if (match[0].rm_so == 0)
-					cspace(&SS,
-					    s, match[0].rm_so + 1, APPEND);
-				else
-					cspace(&SS,
-					    s + match[0].rm_so, 1, APPEND);
-				s += match[0].rm_so + 1;
-				slen -= match[0].rm_so + 1;
-				lastempty = 1;
+				/* Want a later match: append original. */
+				if (match[0].rm_eo)
+					cspace(&SS, s, match[0].rm_eo, APPEND);
+				n--;
 			}
-		} while (slen > 0 && regexec_e(re, s, REG_NOTBOL, 0, slen));
-		/* Copy trailing retained string. */
-		if (slen > 0)
-			cspace(&SS, s, slen, APPEND);
-  		break;
-	default:				/* Nth occurrence */
-		while (--n) {
-			s += match[0].rm_eo;
-			slen -= match[0].rm_eo;
-			if (!regexec_e(re, s, REG_NOTBOL, 0, slen))
-				return (0);
 		}
-		/* FALLTHROUGH */
-	case 1:					/* 1st occurrence */
-		/* Locate start of replaced string. */
-		re_off = match[0].rm_so + (s - ps);
-		/* Copy leading retained string. */
-		cspace(&SS, ps, re_off, APPEND);
-		/* Add in regular expression. */
-		regsub(&SS, s, cp->u.s->new);
-		/* Copy trailing retained string. */
+
+		/* Move past this match. */
 		s += match[0].rm_eo;
 		slen -= match[0].rm_eo;
+
+		/*
+		 * After a zero-length match, advance one byte,
+		 * and at the end of the line, terminate.
+		 */
+		if (match[0].rm_so == match[0].rm_eo) {
+			if (*s == '\0' || *s == '\n')
+				slen = -1;
+			else
+				slen--;
+			if (*s != '\0')
+			 	cspace(&SS, s++, 1, APPEND);
+			lastempty = 1;
+		} else
+			lastempty = 0;
+
+	} while (n >= 0 && slen >= 0 && regexec_e(re, s, REG_NOTBOL, 0, slen));
+
+	/* Did not find the requested number of matches. */
+	if (n > 1)
+		return (0);
+
+	/* Copy the trailing retained string. */
+	if (slen > 0)
 		cspace(&SS, s, slen, APPEND);
-		break;
-	}
 
 	/*
 	 * Swap the substitute space and the pattern space, and make sure
@@ -394,20 +410,22 @@ substitute(cp)
 	 */
 	tspace = PS;
 	PS = SS;
+	psanl = tspace.append_newline;
 	SS = tspace;
 	SS.space = SS.back;
 
 	/* Handle the 'p' flag. */
 	if (cp->u.s->p)
-		OUT(ps)
+		OUT();
 
 	/* Handle the 'w' flag. */
 	if (cp->u.s->wfile && !pd) {
 		if (cp->u.s->wfd == -1 && (cp->u.s->wfd = open(cp->u.s->wfile,
 		    O_WRONLY|O_APPEND|O_CREAT|O_TRUNC, DEFFILEMODE)) == -1)
-			err(FATAL, "%s: %s\n", cp->u.s->wfile, strerror(errno));
-		if (write(cp->u.s->wfd, ps, psl) != psl)
-			err(FATAL, "%s: %s\n", cp->u.s->wfile, strerror(errno));
+			error(FATAL, "%s: %s", cp->u.s->wfile, strerror(errno));
+		if (write(cp->u.s->wfd, ps, psl) != psl ||
+		    write(cp->u.s->wfd, "\n", 1) != 1)
+			error(FATAL, "%s: %s", cp->u.s->wfile, strerror(errno));
 	}
 	return (1);
 }
@@ -417,17 +435,17 @@ substitute(cp)
  * therefore it also resets the substitution done (sdone) flag.
  */
 static void
-flush_appends()
+flush_appends(void)
 {
 	FILE *f;
 	int count, i;
 	char buf[8 * 1024];
 
-	for (i = 0; i < appendx; i++) 
+	for (i = 0; i < appendx; i++)
 		switch (appends[i].type) {
 		case AP_STRING:
-			fwrite(appends[i].s, sizeof(char), appends[i].len, 
-			    stdout);
+			fwrite(appends[i].s, sizeof(char), appends[i].len,
+			    outfile);
 			break;
 		case AP_FILE:
 			/*
@@ -440,90 +458,80 @@ flush_appends()
 			 */
 			if ((f = fopen(appends[i].s, "r")) == NULL)
 				break;
-			while (count = fread(buf, sizeof(char), sizeof(buf), f))
-				(void)fwrite(buf, sizeof(char), count, stdout);
+			while ((count = fread(buf, sizeof(char), sizeof(buf), f)))
+				(void)fwrite(buf, sizeof(char), count, outfile);
 			(void)fclose(f);
 			break;
 		}
-	if (ferror(stdout))
-		err(FATAL, "stdout: %s", strerror(errno ? errno : EIO));
+	if (ferror(outfile))
+		error(FATAL, "%s: %s", outfname, strerror(errno ? errno : EIO));
 	appendx = sdone = 0;
 }
 
 static void
-lputs(s)
-	register char *s;
+lputs(char *s)
 {
-	register int count;
-	register char *escapes, *p;
-	struct winsize win;
-	static int termwidth = -1;
+	int count;
+	extern int termwidth;
+	const char *escapes;
+	char *p;
 
-	if (termwidth == -1)
-		if (p = getenv("COLUMNS"))
-			termwidth = atoi(p);
-		else if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &win) == 0 &&
-		    win.ws_col > 0)
-			termwidth = win.ws_col;
-		else
-			termwidth = 60;
-
-	for (count = 0; *s; ++s) { 
+	for (count = 0; *s; ++s) {
 		if (count >= termwidth) {
-			(void)printf("\\\n");
+			(void)fprintf(outfile, "\\\n");
 			count = 0;
 		}
-		if (isascii(*s) && isprint(*s) && *s != '\\') {
-			(void)putchar(*s);
+		if (isascii((unsigned char)*s) && isprint((unsigned char)*s)
+		    && *s != '\\') {
+			(void)fputc(*s, outfile);
 			count++;
+		} else if (*s == '\n') {
+			(void)fputc('$', outfile);
+			(void)fputc('\n', outfile);
+			count = 0;
 		} else {
-			escapes = "\\\a\b\f\n\r\t\v";
-			(void)putchar('\\');
-			if (p = strchr(escapes, *s)) {
-				(void)putchar("\\abfnrtv"[p - escapes]);
+			escapes = "\\\a\b\f\r\t\v";
+			(void)fputc('\\', outfile);
+			if ((p = strchr(escapes, *s))) {
+				(void)fputc("\\abfrtv"[p - escapes], outfile);
 				count += 2;
 			} else {
-				(void)printf("%03o", *(u_char *)s);
+				(void)fprintf(outfile, "%03o", *(u_char *)s);
 				count += 4;
 			}
 		}
 	}
-	(void)putchar('$');
-	(void)putchar('\n');
-	if (ferror(stdout))
-		err(FATAL, "stdout: %s", strerror(errno ? errno : EIO));
+	(void)fputc('$', outfile);
+	(void)fputc('\n', outfile);
+	if (ferror(outfile))
+		error(FATAL, "%s: %s", outfname, strerror(errno ? errno : EIO));
 }
 
 static inline int
-regexec_e(preg, string, eflags, nomatch, slen)
-	regex_t *preg;
-	const char *string;
-	int eflags, nomatch;
-	size_t slen;
+regexec_e(regex_t *preg, const char *string, int eflags,
+    int nomatch, size_t slen)
 {
 	int eval;
-	
+
 	if (preg == NULL) {
 		if (defpreg == NULL)
-			err(FATAL, "first RE may not be empty");
+			error(FATAL, "first RE may not be empty");
 	} else
 		defpreg = preg;
 
-	/* Set anchors, discounting trailing newline (if any). */
-	if (slen > 0 && string[slen - 1] == '\n')
-		slen--;
+	/* Set anchors */
 	match[0].rm_so = 0;
 	match[0].rm_eo = slen;
-	
+
 	eval = regexec(defpreg, string,
 	    nomatch ? 0 : maxnsub + 1, match, eflags | REG_STARTEND);
-	switch(eval) {
+	switch (eval) {
 	case 0:
 		return (1);
 	case REG_NOMATCH:
 		return (0);
 	}
-	err(FATAL, "RE error: %s", strregerror(eval, defpreg));
+	error(FATAL, "RE error: %s", strregerror(eval, defpreg));
 	/* NOTREACHED */
 }
 
@@ -532,17 +540,16 @@ regexec_e(preg, string, eflags, nomatch, slen)
  * Based on a routine by Henry Spencer
  */
 static void
-regsub(sp, string, src)
-	SPACE *sp;
-	char *string, *src;
+regsub(SPACE *sp, char *string, char *src)
 {
-	register int len, no;
-	register char c, *dst;
+	int len, no;
+	char c, *dst;
 
 #define	NEEDSP(reqlen)							\
-	if (sp->len >= sp->blen - (reqlen) - 1) {			\
-		sp->blen += (reqlen) + 1024;				\
-		sp->space = sp->back = xrealloc(sp->back, sp->blen);	\
+	if (sp->len + (reqlen) + 1 >= sp->blen) {			\
+		size_t newlen = sp->blen + (reqlen) + 1024;		\
+		sp->space = sp->back = xrealloc(sp->back, newlen);	\
+		sp->blen = newlen;					\
 		dst = sp->space + sp->len;				\
 	}
 
@@ -550,7 +557,7 @@ regsub(sp, string, src)
 	while ((c = *src++) != '\0') {
 		if (c == '&')
 			no = 0;
-		else if (c == '\\' && isdigit(*src))
+		else if (c == '\\' && isdigit((unsigned char)*src))
 			no = *src++ - '0';
 		else
 			no = -1;
@@ -578,19 +585,16 @@ regsub(sp, string, src)
  *	space as necessary.
  */
 void
-cspace(sp, p, len, spflag)
-	SPACE *sp;
-	char *p;
-	size_t len;
-	enum e_spflag spflag;
+cspace(SPACE *sp, const char *p, size_t len, enum e_spflag spflag)
 {
 	size_t tlen;
 
 	/* Make sure SPACE has enough memory and ramp up quickly. */
 	tlen = sp->len + len + 1;
 	if (tlen > sp->blen) {
-		sp->blen = tlen + 1024;
-		sp->space = sp->back = xrealloc(sp->back, sp->blen);
+		size_t newlen = tlen + 1024;
+		sp->space = sp->back = xrealloc(sp->back, newlen);
+		sp->blen = newlen;
 	}
 
 	if (spflag == REPLACE)
@@ -605,21 +609,20 @@ cspace(sp, p, len, spflag)
  * Close all cached opened files and report any errors
  */
 void
-cfclose(cp, end)
-	register struct s_command *cp, *end;
+cfclose(struct s_command *cp, struct s_command *end)
 {
 
 	for (; cp != end; cp = cp->next)
-		switch(cp->code) {
+		switch (cp->code) {
 		case 's':
 			if (cp->u.s->wfd != -1 && close(cp->u.s->wfd))
-				err(FATAL,
+				error(FATAL,
 				    "%s: %s", cp->u.s->wfile, strerror(errno));
 			cp->u.s->wfd = -1;
 			break;
 		case 'w':
 			if (cp->u.fd != -1 && close(cp->u.fd))
-				err(FATAL, "%s: %s", cp->t, strerror(errno));
+				error(FATAL, "%s: %s", cp->t, strerror(errno));
 			cp->u.fd = -1;
 			break;
 		case '{':

--- a/usr.bin/sed/reallocarray.c
+++ b/usr.bin/sed/reallocarray.c
@@ -1,0 +1,38 @@
+/*	$OpenBSD: reallocarray.c,v 1.3 2015/09/13 08:31:47 guenther Exp $	*/
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW	((size_t)1 << (sizeof(size_t) * 4))
+
+void *
+reallocarray(void *optr, size_t nmemb, size_t size)
+{
+	if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+	    nmemb > 0 && SIZE_MAX / nmemb < size) {
+		errno = ENOMEM;
+		return NULL;
+	}
+	return realloc(optr, size * nmemb);
+}

--- a/usr.bin/sed/sed.1
+++ b/usr.bin/sed/sed.1
@@ -1,3 +1,5 @@
+.\"	$OpenBSD: sed.1,v 1.47 2015/11/04 21:28:27 tedu Exp $
+.\"
 .\" Copyright (c) 1992, 1993
 .\"	The Regents of the University of California.  All rights reserved.
 .\"
@@ -12,11 +14,7 @@
 .\" 2. Redistributions in binary form must reproduce the above copyright
 .\"    notice, this list of conditions and the following disclaimer in the
 .\"    documentation and/or other materials provided with the distribution.
-.\" 3. All advertising materials mentioning features or use of this software
-.\"    must display the following acknowledgement:
-.\"	This product includes software developed by the University of
-.\"	California, Berkeley and its contributors.
-.\" 4. Neither the name of the University nor the names of its contributors
+.\" 3. Neither the name of the University nor the names of its contributors
 .\"    may be used to endorse or promote products derived from this software
 .\"    without specific prior written permission.
 .\"
@@ -32,9 +30,9 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.\"	@(#)sed.1	8.2 (Berkeley) 12/30/93
+.\"	from: @(#)sed.1	8.2 (Berkeley) 12/30/93
 .\"
-.Dd "December 30, 1993"
+.Dd $Mdocdate: November 4 2015 $
 .Dt SED 1
 .Os
 .Sh NAME
@@ -42,24 +40,28 @@
 .Nd stream editor
 .Sh SYNOPSIS
 .Nm sed
-.Op Fl an
+.Op Fl aEnru
+.Op Fl i Ns Op Ar extension
 .Ar command
-.Op Ar file ...
+.Op Ar
 .Nm sed
-.Op Fl an
+.Op Fl aEnru
 .Op Fl e Ar command
 .Op Fl f Ar command_file
-.Op Ar file ...
+.Op Fl i Ns Op Ar extension
+.Op Ar
 .Sh DESCRIPTION
 The
-.Nm sed
+.Nm
 utility reads the specified files, or the standard input if no files
 are specified, modifying the input as specified by a list of commands.
 The input is then written to the standard output.
 .Pp
 A single command may be specified as the first argument to
 .Nm sed .
-Multiple commands may be specified by using the
+Multiple commands may be specified
+separated by newlines or semicolons,
+or by using the
 .Fl e
 or
 .Fl f
@@ -67,20 +69,23 @@ options.
 All commands are applied to the input in the order they are specified
 regardless of their origin.
 .Pp
-The following options are available:
-.Bl -tag -width indent
+The options are as follows:
+.Bl -tag -width Ds
 .It Fl a
 The files listed as parameters for the
-.Dq w
-functions are created (or truncated) before any processing begins,
+.Ic w
+function or flag are created (or truncated) before any processing begins,
 by default.
 The
 .Fl a
 option causes
-.Nm sed
+.Nm
 to delay opening each file until a command containing the related
-.Dq w
-function is applied to a line of input.
+.Ic w
+function or flag is applied to a line of input.
+.It Fl E
+Interpret regular expressions using POSIX extended regular expression syntax.
+The default behaviour is to use POSIX basic regular expression syntax.
 .It Fl e Ar command
 Append the editing commands specified by the
 .Ar command
@@ -91,46 +96,66 @@ Append the editing commands found in the file
 .Ar command_file
 to the list of commands.
 The editing commands should each be listed on a separate line.
+.It Fl i Ns Op Ar extension
+Edit files in place, saving backups with the specified
+.Ar extension .
+If a zero length
+.Ar extension
+is given, no backup will be saved.
+It is not recommended to give a zero length
+.Ar extension
+when in place editing files, as it risks corruption or partial content
+in situations where disk space is exhausted, etc.
+.It Fl r
+An alias for
+.Fl E ,
+for compatibility with GNU sed.
 .It Fl n
 By default, each line of input is echoed to the standard output after
 all of the commands have been applied to it.
 The
 .Fl n
 option suppresses this behavior.
+.It Fl u
+Force output to be line buffered,
+printing each line as it becomes available.
+By default, output is line buffered when standard output is a terminal
+and block buffered otherwise.
+See
+.Xr setvbuf 3
+for a more detailed explanation.
 .El
 .Pp
 The form of a
-.Nm sed
+.Nm
 command is as follows:
-.sp
+.Pp
 .Dl [address[,address]]function[arguments]
-.sp
+.Pp
 Whitespace may be inserted before the first address and the function
 portions of the command.
 .Pp
 Normally,
-.Nm sed
+.Nm
 cyclically copies a line of input, not including its terminating newline
 character, into a
-.Em "pattern space" ,
+.Em pattern space ,
 (unless there is something left after a
-.Dq D
+.Ic D
 function),
 applies all of the commands with addresses that select that pattern space,
 copies the pattern space to the standard output, appending a newline, and
 deletes the pattern space.
 .Pp
 Some of the functions use a
-.Em "hold space"
+.Em hold space
 to save all or part of the pattern space for subsequent retrieval.
-.Sh "Sed Addresses"
+.Sh SED ADDRESSES
 An address is not required, but if specified must be a number (that counts
 input lines
-cumulatively across input files), a dollar
-.Po
-.Dq $
-.Pc
-character that addresses the last line of input, or a context address
+cumulatively across input files), a dollar character
+.Pq Ql $
+that addresses the last line of input, or a context address
 (which consists of a regular expression preceded and followed by a
 delimiter).
 .Pp
@@ -145,42 +170,47 @@ pattern space that matches the second.
 (If the second address is a number less than or equal to the line number
 first selected, only that line is selected.)
 Starting at the first line following the selected range,
-.Nm sed
+.Nm
 starts looking again for the first address.
 .Pp
 Editing commands can be applied to non-selected pattern spaces by use
 of the exclamation character
-.Po
-.Dq !
-.Pc
+.Pq Ql \&!
 function.
-.Sh "Sed Regular Expressions"
-The
-.Nm sed
-regular expressions are basic regular expressions (BRE's, see
-.Xr regex 3
-for more information).
+.Sh SED REGULAR EXPRESSIONS
+By default,
+.Nm
+regular expressions are basic regular expressions
+.Pq BREs .
+Extended regular expressions are supported using the
+.Fl E
+and
+.Fl r
+options.
+See
+.Xr re_format 7
+for more information on regular expressions.
 In addition,
-.Nm sed
-has the following two additions to BRE's:
-.sp
+.Nm
+has the following two additions to BREs:
+.Pp
 .Bl -enum -compact
 .It
 In a context address, any character other than a backslash
-.Po
-.Dq \e
-.Pc
+.Pq Ql \e
 or newline character may be used to delimit the regular expression.
-Also, putting a backslash character before the delimiting character
+The opening delimiter should be preceded by a backslash
+unless it is a slash.
+Putting a backslash character before the delimiting character
 causes the character to be treated literally.
 For example, in the context address \exabc\exdefx, the RE delimiter
 is an
-.Dq x
+.Sq x
 and the second
-.Dq x
+.Sq x
 stands for itself, so that the regular expression is
 .Dq abcxdef .
-.sp
+.Pp
 .It
 The escape sequence \en matches a newline character embedded in the
 pattern space.
@@ -189,10 +219,10 @@ in the substitute command.
 .El
 .Pp
 One special feature of
-.Nm sed
+.Nm
 regular expressions is that they can default to the last regular
 expression used.
-If a regular expression is empty, i.e. just the delimiter characters
+If a regular expression is empty, i.e., just the delimiter characters
 are specified, the last regular expression encountered is used instead.
 The last regular expression is defined as the last regular expression
 used as part of an address or substitute command, and at run-time, not
@@ -203,46 +233,54 @@ will substitute
 .Dq XXX
 for the pattern
 .Dq abc .
-.Sh "Sed Functions"
+.Sh SED FUNCTIONS
 In the following list of commands, the maximum number of permissible
 addresses for each command is indicated by [0addr], [1addr], or [2addr],
 representing zero, one, or two addresses.
 .Pp
 The argument
-.Em text
+.Ar text
 consists of one or more lines.
 To embed a newline in the text, precede it with a backslash.
 Other backslashes in text are deleted and the following character
 taken literally.
 .Pp
 The
-.Dq r
+.Ic r
 and
-.Dq w
-functions take an optional file parameter, which should be separated
-from the function letter by white space.
-Each file given as an argument to
-.Nm sed
-is created (or its contents truncated) before any input processing begins.
+.Ic w
+functions,
+as well as the
+.Cm w
+flag to the
+.Ic s
+function,
+take an optional
+.Ar file
+parameter,
+which should be separated from the function or flag by whitespace.
+Files are created
+(or their contents truncated)
+before any input processing begins.
 .Pp
 The
-.Dq b ,
-.Dq r ,
-.Dq s ,
-.Dq t ,
-.Dq w ,
-.Dq y ,
-.Dq ! ,
+.Ic b ,
+.Ic r ,
+.Ic s ,
+.Ic t ,
+.Ic w ,
+.Ic y ,
 and
-.Dq \&:
+.Ic \&:
 functions all accept additional arguments.
-The following synopses indicate which arguments have to be separated from
-the function letters by white space characters.
+The synopses below indicate which arguments have to be separated from
+the function letters by whitespace characters.
 .Pp
-Two of the functions take a function-list.
-This is a list of
-.Nm sed
-functions separated by newlines, as follows:
+Functions can be combined to form a
+.Em function list ,
+a list of
+.Nm
+functions each followed by a newline, as follows:
 .Bd -literal -offset indent
 { function
   function
@@ -251,87 +289,84 @@ functions separated by newlines, as follows:
 }
 .Ed
 .Pp
-The
-.Dq {
-can be preceded by white space and can be followed by white space.
-The function can be preceded by white space.
-The terminating
-.Dq }
-must be preceded by a newline or optional white space.
-.sp
-.Bl -tag -width "XXXXXX" -compact
-.It [2addr] function-list
-Execute function-list only when the pattern space is selected.
-.sp
-.It [1addr]a\e
-.It text
+The braces can be preceded and followed by whitespace.
+The functions can be preceded by whitespace as well.
+.Pp
+Functions and function lists may be preceded by an exclamation mark,
+in which case they are applied only to lines that are
+.Em not
+selected by the addresses.
+.Bl -tag -width Ds
+.It [2addr] Ar function-list
+Execute
+.Ar function-list
+only when the pattern space is selected.
+.It Xo [1 addr] Ic a Ns \e
 .br
+.Ar text
+.Xc
+.Pp
 Write
-.Em text
+.Ar text
 to standard output immediately before each attempt to read a line of input,
 whether by executing the
-.Dq N
+.Ic N
 function or by beginning a new cycle.
-.sp
-.It [2addr]b[lable]
+.It [2addr] Ns Ic b Bq Ar label
 Branch to the
-.Dq \&:
-function with the specified label.
+.Ic \&:
+function with the specified
+.Ar label .
 If the label is not specified, branch to the end of the script.
-.sp
-.It [2addr]c\e
-.It text
+.It Xo [2addr] Ic c Ns \e
 .br
+.Ar text
+.Xc
+.Pp
 Delete the pattern space.
 With 0 or 1 address or at the end of a 2-address range,
-.Em text
+.Ar text
 is written to the standard output.
-.sp
-.It [2addr]d
+.It [2addr] Ns Ic d
 Delete the pattern space and start the next cycle.
-.sp
-.It [2addr]D
+.It [2addr] Ns Ic D
 Delete the initial segment of the pattern space through the first
 newline character and start the next cycle.
-.sp
-.It [2addr]g
+.It [2addr] Ns Ic g
 Replace the contents of the pattern space with the contents of the
 hold space.
-.sp
-.It [2addr]G
+.It [2addr] Ns Ic G
 Append a newline character followed by the contents of the hold space
 to the pattern space.
-.sp
-.It [2addr]h
+.It [2addr] Ns Ic h
 Replace the contents of the hold space with the contents of the
 pattern space.
-.sp
-.It [2addr]H
+.It [2addr] Ns Ic H
 Append a newline character followed by the contents of the pattern space
 to the hold space.
-.sp
-.It [1addr]i\e
-.It text
+.It Xo [1addr] Ic i Ns \e
 .br
+.Ar text
+.Xc
+.Pp
 Write
-.Em text
+.Ar text
 to the standard output.
-.sp
-.It [2addr]l
+.It [2addr] Ns Ic l
 (The letter ell.)
 Write the pattern space to the standard output in a visually unambiguous
 form.
 This form is as follows:
-.sp
+.Pp
 .Bl -tag -width "carriage-returnXX" -offset indent -compact
 .It backslash
-\e
+\e\e
 .It alert
 \ea
+.It backspace
+\eb
 .It form-feed
 \ef
-.It newline
-\en
 .It carriage-return
 \er
 .It tab
@@ -340,175 +375,204 @@ This form is as follows:
 \ev
 .El
 .Pp
-Nonprintable characters are written as three-digit octal numbers (with a
+Non-printable characters are written as three-digit octal numbers (with a
 preceding backslash) for each byte in the character (most significant byte
 first).
 Long lines are folded, with the point of folding indicated by displaying
 a backslash followed by a newline.
 The end of each line is marked with a
-.Dq $ .
-.sp
-.It [2addr]n
+.Ql $ .
+.It [2addr] Ns Ic n
 Write the pattern space to the standard output if the default output has
 not been suppressed, and replace the pattern space with the next line of
 input.
-.sp
-.It [2addr]N
+.It [2addr] Ns Ic N
 Append the next line of input to the pattern space, using an embedded
 newline character to separate the appended material from the original
 contents.
 Note that the current line number changes.
-.sp
-.It [2addr]p
+.It [2addr] Ns Ic p
 Write the pattern space to standard output.
-.sp
-.It [2addr]P
-Write the pattern space, up to the first newline character to the
-standard output.
-.sp
-.It [1addr]q
+.It [2addr] Ns Ic P
+Write the pattern space, up to the first newline character,
+to the standard output.
+.It [1addr] Ns Ic q
 Branch to the end of the script and quit without starting a new cycle.
-.sp
-.It [1addr]r file
+.It [1addr] Ns Ic r Ar file
 Copy the contents of
-.Em file
+.Ar file
 to the standard output immediately before the next attempt to read a
 line of input.
 If
-.Em file
+.Ar file
 cannot be read for any reason, it is silently ignored and no error
 condition is set.
-.sp
-.It [2addr]s/regular expression/replacement/flags
-Substitute the replacement string for the first instance of the regular
-expression in the pattern space.
+.It [2addr] Ns Ic s Ns / Ns Ar RE Ns / Ns Ar replacement Ns / Ns Ar flags
+Substitute the
+.Ar replacement
+string for the first instance of the regular expression
+.Ar RE
+in the pattern space.
 Any character other than backslash or newline can be used instead of
-a slash to delimit the RE and the replacement.
-Within the RE and the replacement, the RE delimiter itself can be used as
+a slash to delimit the regular expression and the replacement.
+Within the regular expression and the replacement,
+the regular expression delimiter itself can be used as
 a literal character if it is preceded by a backslash.
 .Pp
 An ampersand
-.Po
-.Dq &
-.Pc
-appearing in the replacement is replaced by the string matching the RE.
+.Pq Ql &
+appearing in the replacement is replaced by the string matching the
+regular expression.
 The special meaning of
-.Dq &
+.Ql &
 in this context can be suppressed by preceding it by a backslash.
 The string
-.Dq \e# ,
+.Ql \e# ,
 where
-.Dq #
+.Ql #
 is a digit, is replaced by the text matched
 by the corresponding backreference expression (see
-.Xr re_format 7 ).
+.Xr re_format 7 ) .
 .Pp
 A line can be split by substituting a newline character into it.
 To specify a newline character in the replacement string, precede it with
 a backslash.
 .Pp
 The value of
-.Em flags
+.Ar flags
 in the substitute function is zero or more of the following:
 .Bl -tag -width "XXXXXX" -offset indent
-.It "0 ... 9"
+.It Cm 0 No ... Cm 9
 Make the substitution only for the N'th occurrence of the regular
 expression in the pattern space.
-.It g
+.It Cm g
 Make the substitution for all non-overlapping matches of the
 regular expression, not just the first one.
-.It p
+.It Cm p
 Write the pattern space to standard output if a replacement was made.
 If the replacement string is identical to that which it replaces, it
 is still considered to have been a replacement.
-.It w Em file
+.It Cm w Ar file
 Append the pattern space to
-.Em file
+.Ar file
 if a replacement was made.
 If the replacement string is identical to that which it replaces, it
 is still considered to have been a replacement.
 .El
-.sp
-.It [2addr]t [label]
+.It [2addr] Ns Ic t Bq Ar label
 Branch to the
-.Dq :
-function bearing the label if any substitutions have been made since the
+.Ic \&:
+function bearing the
+.Ar label
+if any substitutions have been made since the
 most recent reading of an input line or execution of a
-.Dq t
+.Ic t
 function.
 If no label is specified, branch to the end of the script.
-.sp
-.It [2addr]w Em file
+.It [2addr] Ns Ic w Ar file
 Append the pattern space to the
-.Em file .
-.sp
-.It [2addr]x
+.Ar file .
+.It [2addr] Ns Ic x
 Swap the contents of the pattern and hold spaces.
-.sp
-.It [2addr]y/string1/string2/
+.It [2addr] Ns Ic y Ns / Ns Ar string1 Ns / Ns Ar string2 Ns /
 Replace all occurrences of characters in
-.Em string1
+.Ar string1
 in the pattern space with the corresponding characters from
-.Em string2 .
+.Ar string2 .
 Any character other than a backslash or newline can be used instead of
 a slash to delimit the strings.
 Within
-.Em string1
+.Ar string1
 and
-.Em string2 ,
+.Ar string2 ,
 a backslash followed by any character other than a newline is that literal
-character, and a backslash followed by an ``n'' is replaced by a newline
-character.
-.sp
-.It [2addr]!function
-.It [2addr]!function-list
-Apply the function or function-list only to the lines that are
-.Em not
-selected by the address(es).
-.sp
-.It [0addr]:label
-This function does nothing; it bears a label to which the
-.Dq b
+character, and a backslash followed by an
+.Sq n
+is replaced by a newline character.
+.It [0addr] Ns Ic \&: Ns Ar label
+This function does nothing; it bears a
+.Ar label
+to which the
+.Ic b
 and
-.Dq t
+.Ic t
 commands may branch.
-.sp
-.It [1addr]=
-Write the line number to the standard output followed by a newline
-character.
-.sp
+.It [1addr] Ns Ic =
+Write the line number to the standard output followed by a newline character.
 .It [0addr]
 Empty lines are ignored.
-.sp
-.It [0addr]#
+.It [0addr] Ns Ic #
 The
-.Dq #
+.Ql #
 and the remainder of the line are ignored (treated as a comment), with
 the single exception that if the first two characters in the file are
-.Dq #n ,
+.Ql #n ,
 the default output is suppressed.
 This is the same as specifying the
 .Fl n
 option on the command line.
 .El
-.Pp
-The
-.Nm sed
-utility exits 0 on success and >0 if an error occurs.
+.Sh EXIT STATUS
+.Ex -std sed
+.Sh EXAMPLES
+The following simulates the
+.Xr cat 1
+.Fl s
+command,
+squeezing excess empty lines from standard input:
+.Bd -literal -offset indent
+$ sed -n '
+# Write non-empty lines.
+/./ {
+    p
+    d
+    }
+# Write a single empty line, then look for more empty lines.
+/^$/    p
+# Get the next line, discard the held <newline> (empty line),
+# and look for more empty lines.
+:Empty
+/^$/    {
+    N
+    s/.//
+    b Empty
+    }
+# Write the non-empty line before going back to search
+# for the first in a set of empty lines.
+    p
+\&'
+.Ed
 .Sh SEE ALSO
 .Xr awk 1 ,
 .Xr ed 1 ,
 .Xr grep 1 ,
-.Xr regex 3 ,
 .Xr re_format 7
-.Sh HISTORY
-A
-.Nm sed
-command appeared in
-.At v7 .
 .Sh STANDARDS
 The
-.Nm sed
-function is expected to be a superset of the
-.St -p1003.2
+.Nm
+utility is compliant with the
+.St -p1003.1-2008
 specification.
+.Pp
+The flags
+.Op Fl aEiru
+are extensions to that specification.
+.Pp
+The use of newlines to separate multiple commands on the command line
+is non-portable;
+the use of newlines to separate multiple commands within a command file
+.Pq Fl f Ar command_file
+is portable.
+.Sh HISTORY
+A
+.Nm
+command appeared in
+.At v7 .
+.Sh CAVEATS
+The use of semicolons to separate multiple commands
+is not permitted for the following commands:
+.Ic a , b , c ,
+.Ic i , r , t ,
+.Ic w , \&: ,
+and
+.Ic # .


### PR DESCRIPTION
It's only a little bit bigger than the old sed and gives us some modern options (such as the ubiquitous non-standard -i option).
Should also fix #3.