### PR TITLE
Add -h flag to ls

### DIFF
--- a/bin/ls/Makefile
+++ b/bin/ls/Makefile
@@ -3,4 +3,7 @@
 PROG=	ls
 SRCS=	cmp.c stat_flags.c ls.c print.c util.c
 
+CFLAGS+=-ffunction-sections -fdata-sections
+LDFLAGS+=-Wl,--gc-sections
+
 .include <bsd.prog.mk>

--- a/bin/ls/ls.h
+++ b/bin/ls/ls.h
@@ -42,6 +42,7 @@ extern long blocksize;		/* block size units */
 
 extern int f_accesstime;	/* use time of last access */
 extern int f_flags;		/* show flags associated with a file */
+extern int f_humanize;		/* humanize size field */
 extern int f_inode;		/* print inode */
 extern int f_longform;		/* long listing format */
 extern int f_sectime;		/* print the real time for all files */
@@ -52,6 +53,7 @@ extern int f_type;		/* add type character for non-regular files */
 typedef struct {
 	FTSENT *list;
 	u_long btotal;
+	u_long stotal;
 	int bcfile;
 	int entries;
 	int maxlen;


### PR DESCRIPTION
Due to aggressive CFLAGS and LDFLAGS, the new ls is smaller than the old ls even with the new flag.
This comes via NetBSD:
Revision 1.53 / (download) - annotate - [select for diffs], Fri Dec 26 06:19:19 2003 UTC (12 years ago) by grant
Branch: MAIN
Changes since 1.52: +26 -10 lines
Diff to previous 1.52 (colored)

implement -h(umanize).

from David P. Reese Jr. in PR bin/23870.