### PR TITLE
strip all /usr/bin binaries by default

### DIFF
--- a/usr.bin/Makefile.inc
+++ b/usr.bin/Makefile.inc
@@ -1,3 +1,4 @@
 #	@(#)Makefile.inc	8.1 (Berkeley) 6/6/93
 
 BINDIR?=	/usr/bin
+LDFLAGS+=	-s		# /usr/bin binaries are stripped by default


### PR DESCRIPTION
Hi Serge --
What do you think about stripping all the binaries in /usr/bin by default? It'll make the binaries a lot smaller (even if it doesn't necessarily help with other things).
We can be more aggressive later (I eventually want all the binaries to be stripped and built with -ffunction-sections -fdata-sections/Wl,--gc-sections to make them as small as possible) but this is a start and if something gets broken, we're likely to hear about it quickly.