### PR TITLE
GNU libtool is too stupid to work with relative directories. And since we can't fix libtool.

### DIFF
--- a/share/mk-pic32/bsd.port.mk
+++ b/share/mk-pic32/bsd.port.mk
@@ -5,7 +5,7 @@
 THISISAPORT="Yes"
 .include <bsd.prog.mk>
 
-FAKEDIR=./work
+FAKEDIR=${.CURDIR}/work
 PREFIX=/usr/local
 BINDIR=${PREFIX}/bin
 LOCALBASE=${PREFIX}


### PR DESCRIPTION
(My fault: this was supposed to be committed directly to the master branch.)