### PR TITLE
Add help(1), which is really man(1) executed as "man help"

### DIFF
--- a/etc/rootfs.manifest
+++ b/etc/rootfs.manifest
@@ -913,7 +913,11 @@ file /usr/bin/luac
 file /usr/bin/m4
 file /usr/bin/mail
 file /usr/bin/make
+
 file /usr/bin/man
+symlink /usr/bin/help
+target man
+
 file /usr/bin/mesg
 file /usr/bin/mg
 file /usr/bin/mkdep
@@ -1842,6 +1846,7 @@ file /usr/share/man/cat1/grep.0
 file /usr/share/man/cat1/groups.0
 file /usr/share/man/cat1/gzip.0
 file /usr/share/man/cat1/head.0
+file /usr/share/man/cat1/help.0
 file /usr/share/man/cat1/hexdump.0
 file /usr/share/man/cat1/hostname.0
 file /usr/share/man/cat1/id.0

--- a/usr.bin/man/Makefile
+++ b/usr.bin/man/Makefile
@@ -2,7 +2,10 @@
 
 PROG=	man
 SRCS=	config.c man.c
-MAN1=	man.0
+MAN1=	man.0 help.0
 MAN5=	man.conf.0
+
+CFLAGS+= -ffunction-sections -fdata-sections
+LDFLAGS+= -Wl,--gc-sections
 
 .include <bsd.prog.mk>

--- a/usr.bin/man/help.1
+++ b/usr.bin/man/help.1
@@ -1,0 +1,204 @@
+.\"	$OpenBSD: help.1,v 1.12 2013/07/16 00:07:52 schwarze Exp $
+.\"
+.\" Copyright (c) 1999 Aaron Campbell
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\"
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+.\" IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+.\" OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+.\" IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+.\" INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+.\" NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+.\" DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+.\" THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+.\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+.\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+.\"
+.Dd $Mdocdate: July 16 2013 $
+.Dt HELP 1
+.Os
+.Sh NAME
+.Nm help
+.Nd help for new users and administrators
+.Sh DESCRIPTION
+This document is meant to familiarize new users and system administrators with
+.\" .Ox
+LiteBSD
+and, if necessary,
+.Ux
+in general.
+.Pp
+Firstly, a wealth of information is contained within the system manual pages.
+In
+.Ux ,
+the
+.Xr man 1
+command is used to view them.
+Type
+.Ic man man
+for instructions on how to use it properly.
+Pay especially close attention to the
+.Fl k
+option.
+.Pp
+Other
+.\" .Ox
+LiteBSD
+resources include the forum, located at
+.Lk http://retrobsd.org/index.php ,
+which wecolmes all users, developers, and system administrators of all
+.Ux
+skill levels.
+There is also a GitHub repository of the
+.\" .Ox
+LiteBSD
+code; see
+.Lk https://github.com/sergev/LiteBSD .
+Finally, there is a separate GitHub repository for
+LiteBSD
+ports; see
+.Lk https://github.com/ibara/LiteBSD-Ports .
+This second repository contains third-party software that can be built
+by users in lieu of using binary packages.
+.Ss The Unix shell
+After logging in, some system messages are typically displayed, and then the
+user is able to enter commands to be processed by the shell program.
+The shell is a command-line interpreter that reads user input (normally from
+a terminal) and executes commands.
+There are many different shells available;
+.\" .Ox
+LiteBSD
+ships with
+.Xr ash 1 ,
+.Xr csh 1 ,
+and
+.Xr ksh 1 .
+Each user's shell is indicated by the last field of their corresponding entry
+in the system password file
+.Pf ( Pa /etc/passwd ) .
+Note that
+.Xr ksh 1
+is the default shell for users; it is likely what you are using now.
+It is also the default
+.Xr sh 1 .
+.Ss Basic Unix commands
+.Bl -tag -width "chmodXXX"
+.It Cm man
+Interface to the system manual pages.
+For any of the commands listed below, type
+.Ic man <command>
+for detailed information on what it does and how to use it.
+.It Cm pwd
+Print working directory.
+Files are organized in a hierarchy (see
+.Xr hier 7 )
+called a tree.
+This command will indicate in which directory you are currently located.
+.It Cm cd
+Change working directory.
+Use this command to navigate throughout the file hierarchy.
+For example, type
+.Ic cd /
+to change the working directory to the root.
+.It Cm ls
+List directory contents.
+Type
+.Ic ls -l
+for a detailed listing.
+.It Cm cat
+Although it has many more uses,
+.Ic cat filename
+will print the contents of a plain-text file to the screen.
+.It Cm mkdir
+Make a directory.
+For example,
+.Ic mkdir foobar .
+.It Cm rmdir
+Remove a directory.
+.It Cm rm
+Remove files.
+Files are generally only removable by their owners.
+See the
+.Xr chmod 1
+command for information on file permissions.
+.It Cm chmod
+Change file modes, including permissions.
+It is not immediately obvious how to use this command; please read its manual
+page carefully, as proper file permissions, especially on system files, are
+vital in maintaining security and integrity.
+.It Cm cp
+Copy files.
+.It Cm mv
+Move and rename files.
+.It Cm ps
+List active processes.
+Most
+.Ux Ns -based
+operating systems, including
+.\" .Ox ,
+LiteBSD,
+are multitasking, meaning many programs share system resources at the same
+time.
+A common usage is
+.Ic ps -auxw ,
+which will display information about all active processes.
+.It Cm kill
+Kill processes.
+Used mostly for terminating run-away/unresponsive programs, but also used to
+signal programs for requesting certain operations (e.g., re-read their
+configuration).
+.It Cm date
+Print the current system date and time.
+.It Cm mail
+Access mailbox.
+.It Cm exit
+Log out of the system.
+.El
+.Pp
+When a command is entered, it is first checked to see if it is built-in to the
+shell.
+If not, the shell looks for the command in any directories contained within the
+.Ev PATH
+environment variable (see
+.Xr environ 7 ) .
+If the command is not found, an error message is printed.
+Otherwise, the shell runs the command, passing it any arguments specified on
+the command line.
+.Pp
+Shell built-in commands do not have their own manual page,
+so it's necessary to read the manual page for the user's shell.
+Tools such as
+.Xr which 1
+and
+.Dq whence ,
+a
+.Xr ksh 1
+built-in command,
+can be used to see what commands are being executed.
+.Sh SEE ALSO
+.Xr ash 1 ,
+.Xr csh 1 ,
+.Xr ksh 1 ,
+.Xr man 1 ,
+.Xr whatis 1 ,
+.Xr whereis 1 ,
+.Xr which 1
+.Sh HISTORY
+This manual page was written by
+.An Aaron Campbell Aq Mt aaron@openbsd.org
+and first appeared in
+.Ox 2.6 .
+It was adapted slighty for
+LiteBSD
+by
+.An Brian Callahan Aq Mt bcallah@devio.us .

--- a/usr.bin/man/man.c
+++ b/usr.bin/man/man.c
@@ -50,6 +50,7 @@ static char sccsid[] = "@(#)man.c	8.17 (Berkeley) 1/31/95";
 #include <fcntl.h>
 #include <fnmatch.h>
 #include <glob.h>
+#include <libgen.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -60,6 +61,8 @@ static char sccsid[] = "@(#)man.c	8.17 (Berkeley) 1/31/95";
 #include "pathnames.h"
 
 int f_all, f_where;
+
+extern char *__progname;
 
 static void	 build_page __P((char *, char **));
 static void	 cat __P((char *));
@@ -85,6 +88,15 @@ main(argc, argv)
 	int ch, f_cat, f_how, found;
 	char **ap, *cmd, *machine, *p, *p_add, *p_path, *pager, *slashp;
 	char *conffile, buf[MAXPATHLEN * 2];
+
+	if (argv[1] == NULL && strcmp(basename(__progname), "help") == 0) {
+		static char *nargv[3];
+		nargv[0] = "man";
+		nargv[1] = "help";
+		nargv[2] = NULL;
+		argv = nargv;
+		argc = 2;
+	}
 
 	f_cat = f_how = 0;
 	conffile = p_add = p_path = NULL;


### PR DESCRIPTION
Idea from OpenBSD--also use a modified version of OpenBSD help.1

I remember talking to Will Backman (BSDTalk) somewhere about help(1), how he uses OpenBSD when he teaches at his university and how great it is to have the OS do _something_ when a user types "help"