### PR TITLE
Don't have ld(1) search non-existant directories. Eliminates some warnings.

### DIFF
--- a/usr.bin/ld/littlemips_script.ld
+++ b/usr.bin/ld/littlemips_script.ld
@@ -2,7 +2,7 @@
 
 OUTPUT_FORMAT("elf32-littlemips")
 ENTRY(_start)
-SEARCH_DIR("/lib"); SEARCH_DIR("/usr/lib");
+SEARCH_DIR("/usr/lib");
 SECTIONS {
 	PROVIDE (__executable_start = 0x00400000);
 	. = 0x00400000 + SIZEOF_HEADERS;


### PR DESCRIPTION
ld(1) consistently complains that it cannot open /lib. /lib doesn't exist, so don't search it.