### PR TITLE
Added local mkdep that forces the use of mips-[whatever]-gcc

### DIFF
--- a/admin/build/mkdep
+++ b/admin/build/mkdep
@@ -1,0 +1,113 @@
+#!/bin/sh -
+#
+#	$NetBSD: mkdep.gcc.sh,v 1.9 1994/12/23 07:34:59 jtc Exp $
+#
+# Crosscompiling version, nabbed from NetBSD and with gcc changed
+# to m68k-hp-netbsd-gcc and so forth.
+#
+# Copyright (c) 1991, 1993
+#	The Regents of the University of California.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. All advertising materials mentioning features or use of this software
+#    must display the following acknowledgement:
+#	This product includes software developed by the University of
+#	California, Berkeley and its contributors.
+# 4. Neither the name of the University nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+#	@(#)mkdep.gcc.sh	8.1 (Berkeley) 6/6/93
+#
+
+PATH=/bin:/usr/bin:/usr/ucb
+export PATH
+
+D=.depend			# default dependency file is .depend
+append=0
+pflag=
+
+while :
+	do case "$1" in
+		# -a appends to the depend file
+		-a)
+			append=1
+			shift ;;
+
+		# -f allows you to select a makefile name
+		-f)
+			D=$2
+			shift; shift ;;
+
+		# the -p flag produces "program: program.c" style dependencies
+		# so .o's don't get produced
+		-p)
+			pflag=p
+			shift ;;
+		*)
+			break ;;
+	esac
+done
+
+if [ $# = 0 ] ; then
+	echo 'usage: mkdep [-p] [-f depend_file] [cc_flags] file ...'
+	exit 1
+fi
+
+if [ -z "${CC}" ]; then
+	CC=${MIPS_GCC_ROOT}/bin/mips-sde-elf-gcc
+	if [ ! -f ${CC} ]; then
+		CC=${MIPS_GCC_ROOT}/bin/mips-elf-gcc
+	fi
+	if [ ! -f ${CC} ]; then
+		echo "Unable to work out what CC should be."
+		exit 10
+	fi
+fi
+
+if [ -z "${DESTDIR}" ]; then
+    DESTDIR=${BSDSRC}/DESTDIR
+fi
+
+TMP=/tmp/mkdep$$
+
+trap 'rm -f $TMP ; exit 1' 1 2 3 13 15
+
+if [ x$pflag = x ]; then
+	${CC} -nostdinc -I${BSDSRC}/include -M "$@" | sed -e 's; \./; ;g' > $TMP
+else
+	${CC} -nostdinc -I${BSDSRC}/include -M "$@" | sed -e 's;\.o :; :;' -e 's; \./; ;g' > $TMP
+fi
+
+if [ $? != 0 ]; then
+	echo 'mkdep: compile failed.'
+	rm -f $TMP
+	exit 1
+fi
+
+if [ $append = 1 ]; then
+	cat $TMP >> $D
+	rm -f $TMP
+else
+	mv $TMP $D
+fi
+exit 0

--- a/share/mk-pic32/bsd.lib.mk
+++ b/share/mk-pic32/bsd.lib.mk
@@ -91,7 +91,7 @@ cleandir:
 .if !target(depend)
 depend: .depend
 .depend: ${SRCS}
-	mkdep ${CFLAGS:M-[ID]*} ${AINC} ${.ALLSRC}
+	${BSDSRC}/admin/build/mkdep ${CFLAGS:M-[ID]*} ${AINC} ${.ALLSRC}
 	@(TMP=/tmp/_depend$$$$; \
 	    sed -e 's/^\([^\.]*\).o *:/\1.o \1.po:/' < .depend > $$TMP; \
 	    mv $$TMP .depend)

--- a/share/mk-pic32/bsd.prog.mk
+++ b/share/mk-pic32/bsd.prog.mk
@@ -111,7 +111,7 @@ cleandir: _PROGSUBDIR
 depend: .depend _PROGSUBDIR
 .depend: ${SRCS}
 .if defined(PROG)
-	mkdep ${MKDEP} ${CFLAGS:M-[ID]*} ${.ALLSRC:M*.c}
+	${BSDSRC}/admin/build/mkdep ${MKDEP} ${CFLAGS:M-[ID]*} ${.ALLSRC:M*.c}
 .endif
 .endif
 

--- a/share/mk-pic32/local.prog.mk
+++ b/share/mk-pic32/local.prog.mk
@@ -111,7 +111,7 @@ cleandir: _PROGSUBDIR
 depend: .depend _PROGSUBDIR
 .depend: ${SRCS}
 .if defined(PROG)
-	mkdep ${MKDEP} ${CFLAGS:M-[ID]*} ${.ALLSRC:M*.c}
+	${BSDSRC}/admin/build/mkdep ${MKDEP} ${CFLAGS:M-[ID]*} ${.ALLSRC:M*.c}
 .endif
 .endif
 


### PR DESCRIPTION
Also adds -nostdinc and -I${BSDSRC}/include to the GCC preprocessing command.