### PR TITLE
Update gettytab to change the default login banner from "4.4 BSD-Lite...

### DIFF
--- a/etc/gettytab
+++ b/etc/gettytab
@@ -9,7 +9,7 @@
 # entries, and in cases where getty is called with no table name
 #
 default:\
-	:ap:fd#1000:im=\r\n\r\n4.4BSD-Lite (%h) (%t)\r\n\r\r\n\r:sp#1200:
+	:ap:fd#1000:im=\r\n\r\nLiteBSD (%h) (%t)\r\n\r\r\n\r:sp#1200:
 
 #
 # Fixed speed entries


### PR DESCRIPTION
…" to "LiteBSD"